### PR TITLE
Support non-master default branch names

### DIFF
--- a/src/cactus.js
+++ b/src/cactus.js
@@ -29,7 +29,7 @@ function generateNextVersion(currentVersion, level) {
   return { version, minorVer, releaseBranchName };
 }
 
-async function approveDiff(repo, currentVersion, endRange = 'master') {
+async function approveDiff(repo, currentVersion, endRange) {
   const range = `v${currentVersion}..${endRange}`;
   const commits = await repo.log([range]);
 
@@ -69,7 +69,7 @@ async function cutReleaseBranch(args) {
 
   // Ask for approval on diff before cutting
   logger.info('Cutting branch', versionInfo.releaseBranchName);
-  const approval = await approveDiff(repo, currentVersion);
+  const approval = await approveDiff(repo, currentVersion, args.master);
 
   // Shell out to run npm version inside tempdir
   cp.execSync(`npm version ${args.level} -m "Release v%s"`, { cwd: tmpdir.name });
@@ -83,8 +83,8 @@ async function cutReleaseBranch(args) {
 
   // the remote used for the initial clone of a git repo is named origin. As far
   // as I know, there isn't a way to change that
-  await clonedRepo.push('origin', 'master');
-  await clonedRepo.push('origin', `master:${versionInfo.releaseBranchName}`);
+  await clonedRepo.push('origin', args.master);
+  await clonedRepo.push('origin', `${args.master}:${versionInfo.releaseBranchName}`);
   await clonedRepo.pushTags('origin');
   // Note that this is the original repo, not the cloned repo
   await repo.pull(args.upstream, { '--rebase': null });

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ yargs
   .command('tag', 'tags a version on a release branch', () => {}, wrap(cactus.tagVersion))
   .group(['upstream'], 'Git Options:')
   .option('upstream', { default: 'origin', describe: 'Upstream remote name'})
+  .group(['master'], 'Git Options:')
+  .option('master', { default: 'master', describe: 'The name of the default/primary branch'})
   .example('git cactus cut', 'Cuts a new release branch (minor)')
   .example('git cactus tag', 'Tags a new version (patch)')
   .argv


### PR DESCRIPTION
Github has been encouraging naming the default branch `main` (see photo). 
Larger discussion [here](https://github.com/github/renaming)

Here, we allow caller to specify the name of their default branch with a `--master` argument which defaults to `master`.

<img width="1229" alt="Screen Shot 2022-05-24 at 11 10 11 AM" src="https://user-images.githubusercontent.com/876147/170103569-c352c577-5ea7-4f70-9514-30958ef29f8a.png">
